### PR TITLE
Make `StableHasher::finish` return a small hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
 
+- `StableHasher::finish` now returns a small hash instead of being fatal (#6)
 - Remove `StableHasher::finalize` (#4)
 - Import stable hasher implementation from rustc ([db8aca48129](https://github.com/rust-lang/rust/blob/db8aca48129d86b2623e3ac8cbcf2902d4d313ad/compiler/rustc_data_structures/src/))

--- a/src/sip128.rs
+++ b/src/sip128.rs
@@ -502,7 +502,11 @@ impl Hasher for SipHasher128 {
     }
 
     fn finish(&self) -> u64 {
-        panic!("SipHasher128 cannot provide valid 64 bit hashes")
+        let mut buf = self.buf.clone();
+        let [a, b] = SipHasher128::finish128_inner(self.nbuf, &mut buf, self.state, self.processed);
+
+        // Combining the two halves makes sure we get a good quality hash.
+        a.wrapping_mul(3).wrapping_add(b).to_le()
     }
 }
 

--- a/src/sip128.rs
+++ b/src/sip128.rs
@@ -377,41 +377,47 @@ impl SipHasher128 {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn finish128(mut self) -> [u64; 2] {
-        debug_assert!(self.nbuf < BUFFER_SIZE);
+        SipHasher128::finish128_inner(self.nbuf, &mut self.buf, self.state, self.processed)
+    }
+
+    #[inline]
+    fn finish128_inner(
+        nbuf: usize,
+        buf: &mut [MaybeUninit<u64>; BUFFER_WITH_SPILL_CAPACITY],
+        mut state: State,
+        processed: usize,
+    ) -> [u64; 2] {
+        debug_assert!(nbuf < BUFFER_SIZE);
 
         // Process full elements in buffer.
-        let last = self.nbuf / ELEM_SIZE;
-
-        // Since we're consuming self, avoid updating members for a potential
-        // performance gain.
-        let mut state = self.state;
+        let last = nbuf / ELEM_SIZE;
 
         for i in 0..last {
-            let elem = unsafe { self.buf.get_unchecked(i).assume_init().to_le() };
+            let elem = unsafe { buf.get_unchecked(i).assume_init().to_le() };
             state.v3 ^= elem;
             Sip13Rounds::c_rounds(&mut state);
             state.v0 ^= elem;
         }
 
         // Get remaining partial element.
-        let elem = if self.nbuf % ELEM_SIZE != 0 {
+        let elem = if nbuf % ELEM_SIZE != 0 {
             unsafe {
                 // Ensure element is initialized by writing zero bytes. At most
                 // `ELEM_SIZE - 1` are required given the above check. It's safe
                 // to write this many because we have the spill and we maintain
                 // `self.nbuf` such that this write will start before the spill.
-                let dst = (self.buf.as_mut_ptr() as *mut u8).add(self.nbuf);
+                let dst = (buf.as_mut_ptr() as *mut u8).add(nbuf);
                 ptr::write_bytes(dst, 0, ELEM_SIZE - 1);
-                self.buf.get_unchecked(last).assume_init().to_le()
+                buf.get_unchecked(last).assume_init().to_le()
             }
         } else {
             0
         };
 
         // Finalize the hash.
-        let length = self.processed.debug_strict_add(self.nbuf);
+        let length = processed.debug_strict_add(nbuf);
         let b: u64 = ((length as u64 & 0xff) << 56) | elem;
 
         state.v3 ^= b;

--- a/src/sip128/tests.rs
+++ b/src/sip128/tests.rs
@@ -303,3 +303,13 @@ fn test_fill_buffer() {
     test_fill_buffer!(i128, write_i128);
     test_fill_buffer!(isize, write_isize);
 }
+
+#[test]
+fn test_finish() {
+    let mut hasher = SipHasher128::new_with_keys(0, 0);
+
+    hasher.write_isize(0xF0);
+    hasher.write_isize(0xF0010);
+
+    assert_eq!(hasher.finish(), hasher.finish());
+}

--- a/src/stable_hasher.rs
+++ b/src/stable_hasher.rs
@@ -97,16 +97,11 @@ impl fmt::Debug for StableHasher {
 }
 
 impl Hasher for StableHasher {
-    /// <div class="warning">
+    /// Returns a combined hash.
     ///
-    /// Do not use this function, it will unconditionnaly panic.
-    ///
-    /// Use instead [`StableHasher::finish`] which returns a
-    /// `[u64; 2]` for greater precision.
-    ///
-    /// </div>
+    /// For greater precision use instead [`StableHasher::finish`].
     fn finish(&self) -> u64 {
-        panic!("use StableHasher::finalize instead");
+        self.state.finish()
     }
 
     #[inline]


### PR DESCRIPTION
This PR changes `SipHasher128` and `StableHasher` so that their `finish` implementation are no longer fatal and return a "small hash".

Implements https://github.com/rust-lang/rustc-stable-hash/pull/3#discussion_r1647713568
r? @michaelwoerister