### PR TITLE
Introduce multi hasher support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Use new-type for returned-hash of `SipHasher128`(`Hash`) (#8)
 - Introduce multi hasher support (#8)
 - `StableHasher::finish` now returns a small hash instead of being fatal (#6)
 - Remove `StableHasher::finalize` (#4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Rename `StableHasherResult` to `FromStableHash` (#8)
 - Use new-type for returned-hash of `SipHasher128`(`Hash`) (#8)
 - Introduce multi hasher support (#8)
 - `StableHasher::finish` now returns a small hash instead of being fatal (#6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Introduce multi hasher support (#8)
 - `StableHasher::finish` now returns a small hash instead of being fatal (#6)
 - Remove `StableHasher::finalize` (#4)
 - Import stable hasher implementation from rustc ([db8aca48129](https://github.com/rust-lang/rust/blob/db8aca48129d86b2623e3ac8cbcf2902d4d313ad/compiler/rustc_data_structures/src/))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,11 @@ pub use stable_hasher::StableHasher;
 
 #[doc(inline)]
 pub use stable_hasher::StableHasherResult;
+
+#[doc(inline)]
+pub use stable_hasher::ExtendedHasher;
+
+pub use sip128::SipHasher128; // TODO: Should SipHasher128 be exposed?
+
+/// Stable Sip Hasher 128
+pub type StableSipHasher128 = StableHasher<SipHasher128>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod stable_hasher;
 /// Hashers collection
 pub mod hashers {
     #[doc(inline)]
-    pub use super::sip128::SipHasher128;
+    pub use super::sip128::{SipHasher128, SipHasher128Hash};
 
     /// Stable 128-bits Sip Hasher
     ///
@@ -29,4 +29,4 @@ pub use stable_hasher::StableHasherResult;
 pub use stable_hasher::ExtendedHasher;
 
 #[doc(inline)]
-pub use hashers::StableSipHasher128;
+pub use hashers::{SipHasher128Hash, StableSipHasher128};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod hashers {
 pub use stable_hasher::StableHasher;
 
 #[doc(inline)]
-pub use stable_hasher::StableHasherResult;
+pub use stable_hasher::FromStableHash;
 
 #[doc(inline)]
 pub use stable_hasher::ExtendedHasher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,19 @@ mod int_overflow;
 mod sip128;
 mod stable_hasher;
 
+/// Hashers collection
+pub mod hashers {
+    #[doc(inline)]
+    pub use super::sip128::SipHasher128;
+
+    /// Stable 128-bits Sip Hasher
+    ///
+    /// [`StableHasher`] version of [`SipHasher128`].
+    ///
+    /// [`StableHasher`]: super::StableHasher
+    pub type StableSipHasher128 = super::StableHasher<SipHasher128>;
+}
+
 #[doc(inline)]
 pub use stable_hasher::StableHasher;
 
@@ -15,7 +28,5 @@ pub use stable_hasher::StableHasherResult;
 #[doc(inline)]
 pub use stable_hasher::ExtendedHasher;
 
-pub use sip128::SipHasher128; // TODO: Should SipHasher128 be exposed?
-
-/// Stable Sip Hasher 128
-pub type StableSipHasher128 = StableHasher<SipHasher128>;
+#[doc(inline)]
+pub use hashers::StableSipHasher128;

--- a/src/sip128.rs
+++ b/src/sip128.rs
@@ -41,6 +41,10 @@ const BUFFER_WITH_SPILL_SIZE: usize = BUFFER_WITH_SPILL_CAPACITY * ELEM_SIZE;
 // Index of the spill element in the buffer.
 const BUFFER_SPILL_INDEX: usize = BUFFER_WITH_SPILL_CAPACITY - 1;
 
+/// Hashing result of [`SipHasher128`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SipHasher128Hash(pub [u64; 2]);
+
 #[derive(Debug, Clone)]
 #[repr(C)]
 pub struct SipHasher128 {
@@ -421,7 +425,7 @@ impl Default for SipHasher128 {
 }
 
 impl ExtendedHasher for SipHasher128 {
-    type Hash = [u64; 2];
+    type Hash = SipHasher128Hash;
 
     #[inline]
     fn short_write<const LEN: usize>(&mut self, bytes: [u8; LEN]) {
@@ -446,10 +450,10 @@ impl ExtendedHasher for SipHasher128 {
     }
 
     #[inline(always)]
-    fn finish(mut self) -> [u64; 2] {
-        unsafe {
+    fn finish(mut self) -> SipHasher128Hash {
+        SipHasher128Hash(unsafe {
             SipHasher128::finish128_inner(self.nbuf, &mut self.buf, self.state, self.processed)
-        }
+        })
     }
 }
 

--- a/src/sip128/tests.rs
+++ b/src/sip128/tests.rs
@@ -16,7 +16,7 @@ impl<'a> Hash for Bytes<'a> {
 
 fn hash_with<T: Hash>(mut st: SipHasher128, x: &T) -> [u64; 2] {
     x.hash(&mut st);
-    st.finish128()
+    st.finish()
 }
 
 fn hash<T: Hash>(x: &T) -> [u64; 2] {
@@ -253,8 +253,8 @@ fn test_short_write_works() {
     h2.write(&test_i128.to_ne_bytes());
     h2.write(&test_isize.to_ne_bytes());
 
-    let h1_hash = h1.finish128();
-    let h2_hash = h2.finish128();
+    let h1_hash = h1.finish();
+    let h2_hash = h2.finish();
 
     assert_eq!(h1_hash, h2_hash);
 }
@@ -279,8 +279,8 @@ macro_rules! test_fill_buffer {
             h2.write(s);
             h2.write(x_bytes);
 
-            let h1_hash = h1.finish128();
-            let h2_hash = h2.finish128();
+            let h1_hash = h1.finish();
+            let h2_hash = h2.finish();
 
             assert_eq!(h1_hash, h2_hash);
         }
@@ -306,10 +306,14 @@ fn test_fill_buffer() {
 
 #[test]
 fn test_finish() {
+    fn hash<H: Hasher>(h: &H) -> u64 {
+        h.finish()
+    }
+
     let mut hasher = SipHasher128::new_with_keys(0, 0);
 
     hasher.write_isize(0xF0);
     hasher.write_isize(0xF0010);
 
-    assert_eq!(hasher.finish(), hasher.finish());
+    assert_eq!(hash(&hasher), hash(&hasher));
 }

--- a/src/sip128/tests.rs
+++ b/src/sip128/tests.rs
@@ -14,12 +14,12 @@ impl<'a> Hash for Bytes<'a> {
     }
 }
 
-fn hash_with<T: Hash>(mut st: SipHasher128, x: &T) -> [u64; 2] {
+fn hash_with<T: Hash>(mut st: SipHasher128, x: &T) -> SipHasher128Hash {
     x.hash(&mut st);
     st.finish()
 }
 
-fn hash<T: Hash>(x: &T) -> [u64; 2] {
+fn hash<T: Hash>(x: &T) -> SipHasher128Hash {
     hash_with(SipHasher128::new_with_keys(0, 0), x)
 }
 
@@ -119,7 +119,7 @@ fn test_siphash_1_3_test_vector() {
                 | ((TEST_VECTOR[i][15] as u64) << 56),
         ];
 
-        assert_eq!(out, expected);
+        assert_eq!(out.0, expected);
         input.push(i as u8);
     }
 }

--- a/src/stable_hasher.rs
+++ b/src/stable_hasher.rs
@@ -69,14 +69,15 @@ pub trait ExtendedHasher: Hasher {
 /// # Example
 ///
 /// ```
-/// use rustc_stable_hash::{StableHasher, StableHasherResult, StableSipHasher128};
+/// use rustc_stable_hash::hashers::{StableSipHasher128, SipHasher128Hash};
+/// use rustc_stable_hash::{StableHasher, StableHasherResult};
 /// use std::hash::Hasher;
 ///
 /// struct Hash128([u64; 2]);
 /// impl StableHasherResult for Hash128 {
-///     type Hash = [u64; 2];
+///     type Hash = SipHasher128Hash;
 ///
-///     fn finish(hash: [u64; 2]) -> Hash128 {
+///     fn finish(SipHasher128Hash(hash): SipHasher128Hash) -> Hash128 {
 ///         Hash128(hash)
 ///     }
 /// }
@@ -106,7 +107,7 @@ pub struct StableHasher<H: ExtendedHasher> {
 ///     fn finish(hash: [u64; 2]) -> Hash128 {
 ///         let upper: u128 = hash[0] as u128;
 ///         let lower: u128 = hash[1] as u128;
-///    
+///
 ///         Hash128((upper << 64) | lower)
 ///     }
 /// }

--- a/src/stable_hasher/tests.rs
+++ b/src/stable_hasher/tests.rs
@@ -13,10 +13,10 @@ use crate::{SipHasher128Hash, StableSipHasher128};
 #[derive(Debug, PartialEq)]
 struct TestHash([u64; 2]);
 
-impl StableHasherResult for TestHash {
+impl FromStableHash for TestHash {
     type Hash = SipHasher128Hash;
 
-    fn finish(SipHasher128Hash(hash): Self::Hash) -> TestHash {
+    fn from(SipHasher128Hash(hash): Self::Hash) -> TestHash {
         TestHash(hash)
     }
 }

--- a/src/stable_hasher/tests.rs
+++ b/src/stable_hasher/tests.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
 use super::*;
-use crate::StableSipHasher128;
+use crate::{SipHasher128Hash, StableSipHasher128};
 
 // The tests below compare the computed hashes to particular expected values
 // in order to test that we produce the same results on different platforms,
@@ -14,9 +14,9 @@ use crate::StableSipHasher128;
 struct TestHash([u64; 2]);
 
 impl StableHasherResult for TestHash {
-    type Hash = [u64; 2];
+    type Hash = SipHasher128Hash;
 
-    fn finish(hash: Self::Hash) -> TestHash {
+    fn finish(SipHasher128Hash(hash): Self::Hash) -> TestHash {
         TestHash(hash)
     }
 }

--- a/src/stable_hasher/tests.rs
+++ b/src/stable_hasher/tests.rs
@@ -1,6 +1,7 @@
 use std::hash::Hash;
 
 use super::*;
+use crate::StableSipHasher128;
 
 // The tests below compare the computed hashes to particular expected values
 // in order to test that we produce the same results on different platforms,
@@ -13,7 +14,9 @@ use super::*;
 struct TestHash([u64; 2]);
 
 impl StableHasherResult for TestHash {
-    fn finish(hash: [u64; 2]) -> TestHash {
+    type Hash = [u64; 2];
+
+    fn finish(hash: Self::Hash) -> TestHash {
         TestHash(hash)
     }
 }
@@ -35,7 +38,7 @@ fn test_hash_integers() {
     let test_i128 = -500_i128;
     let test_isize = -600_isize;
 
-    let mut h = StableHasher::new();
+    let mut h = StableSipHasher128::new();
     test_u8.hash(&mut h);
     test_u16.hash(&mut h);
     test_u32.hash(&mut h);
@@ -60,7 +63,7 @@ fn test_hash_usize() {
     // Test that usize specifically is handled consistently across platforms.
     let test_usize = 0xABCDEF01_usize;
 
-    let mut h = StableHasher::new();
+    let mut h = StableSipHasher128::new();
     test_usize.hash(&mut h);
 
     // This depends on the hashing algorithm. See note at top of file.
@@ -74,7 +77,7 @@ fn test_hash_isize() {
     // Test that isize specifically is handled consistently across platforms.
     let test_isize = -7_isize;
 
-    let mut h = StableHasher::new();
+    let mut h = StableSipHasher128::new();
     test_isize.hash(&mut h);
 
     // This depends on the hashing algorithm. See note at top of file.
@@ -84,7 +87,7 @@ fn test_hash_isize() {
 }
 
 fn hash<T: Hash>(t: &T) -> TestHash {
-    let mut h = StableHasher::new();
+    let mut h = StableSipHasher128::new();
     t.hash(&mut h);
     h.finish()
 }


### PR DESCRIPTION
This PR introduce multi `Hasher` support in our `StableHasher` by adding a new trait `ExtendedHasher` that *extended* the hasher trait with support for short writes and custom hash type and hook it up with `StableHasher`.

For brevity here is the API for `ExtendedHasher`:
```rust
/// Extended the [`Hasher`] trait for use with [`StableHasher`].
///
/// It permits returning an arbitrary type as the [`Self::Hash`] type
/// contrary to the [`Hasher`] trait which can only return `u64`. This
/// is useful when the hasher uses a different representation.
pub trait ExtendedHasher: Hasher {
    /// Type returned by the hasher.
    type Hash;

    /// Optimized version of [`Hasher::write`] but for small write.
    fn short_write<const LEN: usize>(&mut self, bytes: [u8; LEN]);

    /// Finalization method of the hasher to return the [`Hash`].
    fn finish(self) -> Self::Hash;
}
```

Unresolved questions:
 - [X] Should we expose `SipHasher128`? or just exposing `StableSipHasher128` is enough?
    - https://github.com/rust-lang/rustc-stable-hash/pull/8#discussion_r1666771473; exposed in the newly created `hashers` module
 - [X] Should `StableHasher::new` exist and call `Default::default`? or should it take a hasher as input?
 	- Added `StableHasher::with_hasher` to handle this.

r? @michaelwoerister
Fixes #5