### PR TITLE
Improve continuous integration checks (rustfmt, rustdoc, clippy)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,30 +22,52 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
-    - run: rustup default stable
-    - run: cargo check
-    - run: cargo test
-    - run: rustup default nightly
-    - run: cargo test --all-features
+      - uses: actions/checkout@v4
+      - run: rustup default stable
+      - run: cargo check
+      - run: cargo test
+      - run: rustup default nightly
+      - run: cargo test --all-features
   cross-test:
     strategy:
       matrix:
         target: [
-          "x86_64-unknown-linux-gnu", # 64-bits, little-endian
-          "i686-unknown-linux-gnu",   # 32-bits, little-endian
-          "mips-unknown-linux-gnu",   # 32-bits, big-endian
-          "mips64-unknown-linux-gnuabi64" # 64-bits, big-endian
-        ]
+            "x86_64-unknown-linux-gnu", # 64-bits, little-endian
+            "i686-unknown-linux-gnu", # 32-bits, little-endian
+            "mips-unknown-linux-gnu", # 32-bits, big-endian
+            "mips64-unknown-linux-gnuabi64", # 64-bits, big-endian
+          ]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
-    - name: install miri
-      run: rustup toolchain add nightly --no-self-update --component miri && rustup default nightly
-    - run: |
-        cargo miri test --target=${{ matrix.target }} --all-features
-      env:
+      - uses: actions/checkout@v4
+      - name: install miri
+        run: rustup toolchain add nightly --no-self-update --component miri && rustup default nightly
+      - run: |
+          cargo miri test --target=${{ matrix.target }} --all-features
+        env:
           MIRIFLAGS: -Zmiri-strict-provenance
           RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -Z randomize-layout
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -Z randomize-layout
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update stable && rustup default stable
+      - run: rustup component add rustfmt
+      - run: cargo fmt --all --check
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update stable && rustup default stable
+      - run: cargo doc --workspace --document-private-items --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update stable && rustup default stable
+      - run: rustup component add clippy
+      - run: cargo clippy --workspace --all-targets --no-deps

--- a/src/int_overflow.rs
+++ b/src/int_overflow.rs
@@ -15,7 +15,7 @@
 ///
 /// That's a long way to say that this should be used in areas where overflow
 /// is a bug but overflow checking is too slow.
-pub trait DebugStrictAdd {
+pub(crate) trait DebugStrictAdd {
     /// See [`DebugStrictAdd`].
     fn debug_strict_add(self, other: Self) -> Self;
 }
@@ -37,7 +37,7 @@ macro_rules! impl_debug_strict_add {
 }
 
 /// See [`DebugStrictAdd`].
-pub trait DebugStrictSub {
+pub(crate) trait DebugStrictSub {
     /// See [`DebugStrictAdd`].
     fn debug_strict_sub(self, other: Self) -> Self;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 //! A stable hashing algorithm used by rustc
 
 #![cfg_attr(feature = "nightly", feature(hasher_prefixfree_extras))]
+#![deny(clippy::missing_safety_doc)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 mod int_overflow;
 mod sip128;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(feature = "nightly", feature(hasher_prefixfree_extras))]
 #![deny(clippy::missing_safety_doc)]
 #![deny(unsafe_op_in_unsafe_fn)]
+#![deny(unreachable_pub)]
 
 mod int_overflow;
 mod sip128;

--- a/src/sip128.rs
+++ b/src/sip128.rs
@@ -408,13 +408,13 @@ impl SipHasher128 {
 
         state.v2 ^= 0xee;
         Sip13Rounds::d_rounds(&mut state);
-        let _0 = state.v0 ^ state.v1 ^ state.v2 ^ state.v3;
+        let l = state.v0 ^ state.v1 ^ state.v2 ^ state.v3;
 
         state.v1 ^= 0xdd;
         Sip13Rounds::d_rounds(&mut state);
-        let _1 = state.v0 ^ state.v1 ^ state.v2 ^ state.v3;
+        let h = state.v0 ^ state.v1 ^ state.v2 ^ state.v3;
 
-        [_0, _1]
+        [l, h]
     }
 }
 
@@ -523,7 +523,7 @@ impl Hasher for SipHasher128 {
     }
 
     fn finish(&self) -> u64 {
-        let mut buf = self.buf.clone();
+        let mut buf = self.buf;
         let [a, b] = unsafe {
             SipHasher128::finish128_inner(self.nbuf, &mut buf, self.state, self.processed)
         };

--- a/src/sip128/tests.rs
+++ b/src/sip128/tests.rs
@@ -98,25 +98,26 @@ fn test_siphash_1_3_test_vector() {
 
     let mut input: Vec<u8> = Vec::new();
 
-    for i in 0..64 {
+    #[allow(clippy::identity_op)]
+    for (i, v) in TEST_VECTOR.iter().enumerate() {
         let out = hash_with(SipHasher128::new_with_keys(k0, k1), &Bytes(&input[..]));
         let expected = [
-            ((TEST_VECTOR[i][0] as u64) << 0)
-                | ((TEST_VECTOR[i][1] as u64) << 8)
-                | ((TEST_VECTOR[i][2] as u64) << 16)
-                | ((TEST_VECTOR[i][3] as u64) << 24)
-                | ((TEST_VECTOR[i][4] as u64) << 32)
-                | ((TEST_VECTOR[i][5] as u64) << 40)
-                | ((TEST_VECTOR[i][6] as u64) << 48)
-                | ((TEST_VECTOR[i][7] as u64) << 56),
-            ((TEST_VECTOR[i][8] as u64) << 0)
-                | ((TEST_VECTOR[i][9] as u64) << 8)
-                | ((TEST_VECTOR[i][10] as u64) << 16)
-                | ((TEST_VECTOR[i][11] as u64) << 24)
-                | ((TEST_VECTOR[i][12] as u64) << 32)
-                | ((TEST_VECTOR[i][13] as u64) << 40)
-                | ((TEST_VECTOR[i][14] as u64) << 48)
-                | ((TEST_VECTOR[i][15] as u64) << 56),
+            ((v[0] as u64) << 0)
+                | ((v[1] as u64) << 8)
+                | ((v[2] as u64) << 16)
+                | ((v[3] as u64) << 24)
+                | ((v[4] as u64) << 32)
+                | ((v[5] as u64) << 40)
+                | ((v[6] as u64) << 48)
+                | ((v[7] as u64) << 56),
+            ((v[8] as u64) << 0)
+                | ((v[9] as u64) << 8)
+                | ((v[10] as u64) << 16)
+                | ((v[11] as u64) << 24)
+                | ((v[12] as u64) << 32)
+                | ((v[13] as u64) << 40)
+                | ((v[14] as u64) << 48)
+                | ((v[15] as u64) << 56),
         ];
 
         assert_eq!(out.0, expected);
@@ -128,21 +129,21 @@ fn test_siphash_1_3_test_vector() {
 #[cfg(target_arch = "arm")]
 fn test_hash_usize() {
     let val = 0xdeadbeef_deadbeef_u64;
-    assert!(hash(&(val as u64)) != hash(&(val as usize)));
+    assert!(hash(&val) != hash(&(val as usize)));
     assert_eq!(hash(&(val as u32)), hash(&(val as usize)));
 }
 #[test]
 #[cfg(target_arch = "x86_64")]
 fn test_hash_usize() {
     let val = 0xdeadbeef_deadbeef_u64;
-    assert_eq!(hash(&(val as u64)), hash(&(val as usize)));
+    assert_eq!(hash(&val), hash(&(val as usize)));
     assert!(hash(&(val as u32)) != hash(&(val as usize)));
 }
 #[test]
 #[cfg(target_arch = "x86")]
 fn test_hash_usize() {
     let val = 0xdeadbeef_deadbeef_u64;
-    assert!(hash(&(val as u64)) != hash(&(val as usize)));
+    assert!(hash(&val) != hash(&(val as usize)));
     assert_eq!(hash(&(val as u32)), hash(&(val as usize)));
 }
 

--- a/src/stable_hasher.rs
+++ b/src/stable_hasher.rs
@@ -125,7 +125,6 @@ impl<H: ExtendedHasher + Default> StableHasher<H> {
     ///
     /// To be used with the [`Hasher`] implementation and [`StableHasher::finish`].
     #[inline]
-    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
@@ -136,7 +135,6 @@ impl<H: ExtendedHasher + Default> Default for StableHasher<H> {
     ///
     /// To be used with the [`Hasher`] implementation and [`StableHasher::finish`].
     #[inline]
-    #[must_use]
     fn default() -> Self {
         StableHasher {
             state: Default::default(),
@@ -153,7 +151,6 @@ impl<H: ExtendedHasher> StableHasher<H> {
     /// is not covered by this crate guarentees and will make the resulting hash
     /// NOT platform independent.
     #[inline]
-    #[must_use]
     pub fn with_hasher(state: H) -> Self {
         StableHasher { state }
     }


### PR DESCRIPTION
This PR improve the CI checks with jobs checking for rustfmt, rustdoc and clippy.

This is done to improve/maintain the code quality of this crate and enable more improvements in the future.
As well as fixing the reported warnings by clippy.

r? @michaelwoerister