### PR TITLE
feat: derive Clone for StableHasher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+# 0.1.1
+
+- feat: derive `Clone` for `StableHasher` [#11][pr11]
+
+[pr11]: https://github.com/rust-lang/rustc-stable-hash/pull/11
+
 # 0.1.0
 
 - Rename `StableHasherResult` to `FromStableHash` [#8][pr8]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "rustc-stable-hash"
-version = "0.1.0"
+version = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc-stable-hash"
-version = "0.1.0"
+version = "0.1.1"
 description = "A stable hashing algorithm used by rustc"
 license = "Apache-2.0 OR MIT"
 readme = "README.md"

--- a/src/stable_hasher.rs
+++ b/src/stable_hasher.rs
@@ -88,6 +88,7 @@ pub trait ExtendedHasher: Hasher {
 /// let hash: Hash128 = hasher.finish();
 /// ```
 #[must_use]
+#[derive(Clone)]
 pub struct StableHasher<H: ExtendedHasher> {
     state: H,
 }

--- a/src/stable_hasher/tests.rs
+++ b/src/stable_hasher/tests.rs
@@ -112,3 +112,24 @@ fn test_isize_compression() {
     check_hash(0xFF, 0xFFFFFFFFFFFFFFFF);
     check_hash(u64::MAX /* -1 */, 1);
 }
+
+#[test]
+fn test_cloned_hasher_output() {
+    // Test that integers are handled consistently across platforms.
+    let test_u8 = 0xAB_u8;
+    let test_u16 = 0xFFEE_u16;
+    let test_u32 = 0x445577AA_u32;
+
+    let mut h1 = StableSipHasher128::new();
+    test_u8.hash(&mut h1);
+    test_u16.hash(&mut h1);
+
+    let h2 = h1.clone();
+    let mut h3 = h1.clone();
+    // Make sure the cloned hasher can be fed more values.
+    test_u32.hash(&mut h3);
+
+    let h1_hash: TestHash = h1.finish();
+    assert_eq!(h1_hash, h2.finish());
+    assert_ne!(h1_hash, h3.finish());
+}


### PR DESCRIPTION
Due to the orphan rule, deriving `Clone` must happen inside this crate.

Cargo needs this because it now clones and diverges `-C metadata` and `-C extra-filename` hashes.
https://github.com/rust-lang/cargo/commit/cdf805e50991a67e51f0ed5258593794df1cdb8f

I _think_ it should be a minor releases not a breaking change,
though I am not 100% sure.

cc @Urgau 